### PR TITLE
feat: include worker scopes when checking for browser runtime

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -5,6 +5,7 @@ import { asAsyncIterable, asyncIteratorToBuffer } from './utils/itr.js'
 import { randomUUID } from './utils/uuid.js'
 import { memoryStorage } from './storage/index.js'
 import { getJWT } from './utils/jwt.js'
+import { isBrowserContext } from './utils/runtime.js'
 
 export class Saturn {
   /**
@@ -34,8 +35,8 @@ export class Saturn {
     this.logs = []
     this.storage = this.opts.storage || memoryStorage()
     this.reportingLogs = process?.env?.NODE_ENV !== 'development'
-    this.hasPerformanceAPI = typeof window !== 'undefined' && window?.performance
-    this.isBrowser = typeof window !== 'undefined'
+    this.hasPerformanceAPI = isBrowserContext && self?.performance
+
     if (this.reportingLogs && this.hasPerformanceAPI) {
       this._monitorPerformanceBuffer()
     }
@@ -69,7 +70,7 @@ export class Saturn {
       controller.abort()
     }, options.connectTimeout)
 
-    if (!this.isBrowser) {
+    if (!isBrowserContext) {
       options.headers = {
         ...(options.headers || {}),
         Authorization: 'Bearer ' + options.jwt
@@ -173,7 +174,7 @@ export class Saturn {
       url.searchParams.set('dag-scope', 'entity')
     }
 
-    if (this.isBrowser) {
+    if (isBrowserContext) {
       url.searchParams.set('jwt', opts.jwt)
     }
 

--- a/src/storage/indexed-db-storage.js
+++ b/src/storage/indexed-db-storage.js
@@ -11,7 +11,7 @@ const DEFAULT_SATURN_STORAGE_NAME = 'saturn-client'
  * @returns {import('./index.js').Storage}
  */
 export function indexedDbStorage () {
-  const indexedDbExists = (typeof window !== 'undefined') && window?.indexedDB
+  const indexedDbExists = (typeof self !== 'undefined') && self?.indexedDB
   let dbPromise
   if (indexedDbExists) {
     dbPromise = openDB(DEFAULT_IDB_STORAGE_NAME, DEFAULT_IDB_VERSION, {

--- a/src/utils/runtime.js
+++ b/src/utils/runtime.js
@@ -1,0 +1,15 @@
+export const isBrowser =
+  typeof window !== 'undefined' && typeof window.document !== 'undefined'
+
+export const isServiceWorker = typeof ServiceWorkerGlobalScope !== 'undefined'
+
+export const isWebWorker = typeof DedicatedWorkerGlobalScope !== 'undefined'
+
+export const isSharedWorker = typeof SharedWorkerGlobalScope !== 'undefined'
+
+export const isBrowserContext = isBrowser || isServiceWorker || isWebWorker || isSharedWorker
+
+export const isNode =
+  typeof process !== 'undefined' &&
+  process.versions != null &&
+  process.versions.node != null


### PR DESCRIPTION
Current checks for window don't account for web workers