### PR TITLE
feat: log node ids with smart client

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -93,7 +93,6 @@ export class Saturn {
     const createFetchPromise = async (origin) => {
       const fetchOptions = { ...options, url: origin }
       const url = this.createRequestURL(cidPath, fetchOptions)
-
       const controller = new AbortController()
       controllers.push(controller)
       const connectTimeout = setTimeout(() => {
@@ -105,9 +104,7 @@ export class Saturn {
         clearTimeout(connectTimeout)
         return { res, url, controller }
       } catch (err) {
-        throw new Error(
-          `Non OK response received: ${res.status} ${res.statusText}`
-        )
+        throw new Error(err)
       }
     }
 

--- a/src/client.js
+++ b/src/client.js
@@ -302,8 +302,7 @@ export class Saturn {
         return
       }
       if (opts.raceNodes) {
-        const origins = nodes.slice(i, i + Saturn.defaultRaceCount)
-        opts.nodes = origins
+        opts.nodes = nodes.slice(i, i + Saturn.defaultRaceCount)
       } else {
         opts.node = nodes[i]
       }

--- a/src/client.js
+++ b/src/client.js
@@ -106,9 +106,8 @@ export class Saturn {
         clearTimeout(connectTimeout)
         return { res, url, node, controller }
       } catch (err) {
-        const error = err
-        error.node = node
-        throw new Error(error)
+        err.node = node
+        throw err
       }
     }
 

--- a/src/client.js
+++ b/src/client.js
@@ -87,8 +87,8 @@ export class Saturn {
 
     let nodes = options.nodes
     if (!nodes || nodes.length === 0) {
-      const replacementUrl = options.node ?? { url: this.opts.cdnURL }
-      nodes = [replacementUrl]
+      const replacementNode = options.node ?? { url: this.opts.cdnURL }
+      nodes = [replacementNode]
     }
     const controllers = []
 

--- a/src/client.js
+++ b/src/client.js
@@ -228,7 +228,7 @@ export class Saturn {
     const { headers } = res
     log.httpStatusCode = res.status
     log.cacheHit = headers.get('saturn-cache-status') === 'HIT'
-    log.nodeId = headers.get('saturn-node-id')
+    log.nodeId = log.nodeId ?? headers.get('saturn-node-id')
     log.requestId = headers.get('saturn-transfer-id')
     log.httpProtocol = headers.get('quic-status')
 

--- a/src/types.js
+++ b/src/types.js
@@ -5,6 +5,7 @@
 /**
  *
  * @typedef {object} Node
+ * @property {string} id
  * @property {string} ip
  * @property {number} weight
  * @property {number} distance

--- a/test/fallback.spec.js
+++ b/test/fallback.spec.js
@@ -82,7 +82,7 @@ describe('Client Fallback', () => {
 
   test('Storage is loaded first when the orch is slower', async (t) => {
     const handlers = [
-      mockOrchHandler(2, TEST_DEFAULT_ORCH, TEST_ORIGIN_DOMAIN, 1000)
+      mockOrchHandler(2, TEST_DEFAULT_ORCH, TEST_ORIGIN_DOMAIN, 500)
     ]
     const server = getMockServer(handlers)
     server.listen(MSW_SERVER_OPTS)

--- a/test/fallback.spec.js
+++ b/test/fallback.spec.js
@@ -8,7 +8,7 @@ import { concatChunks, generateNodes, getMockServer, HTTP_STATUS_GONE, mockJWT, 
 const TEST_DEFAULT_ORCH = 'https://orchestrator.strn.pl/nodes'
 const TEST_NODES_LIST_KEY = 'saturn-nodes'
 const TEST_AUTH = 'https://fz3dyeyxmebszwhuiky7vggmsu0rlkoy.lambda-url.us-west-2.on.aws/'
-const TEST_ORIGIN_DOMAIN = 'saturn.ms'
+const TEST_ORIGIN_DOMAIN = 'https://l1s.saturn.ms'
 const CLIENT_KEY = 'key'
 
 const experimental = true
@@ -37,7 +37,7 @@ describe('Client Fallback', () => {
 
   test('Storage is invoked correctly when supplied', async (t) => {
     const handlers = [
-      mockOrchHandler(2, TEST_DEFAULT_ORCH, 'saturn.ms')
+      mockOrchHandler(2, TEST_DEFAULT_ORCH, TEST_ORIGIN_DOMAIN)
     ]
     const server = getMockServer(handlers)
     server.listen(MSW_SERVER_OPTS)
@@ -75,7 +75,7 @@ describe('Client Fallback', () => {
 
   test('Storage is loaded first when the orch is slower', async (t) => {
     const handlers = [
-      mockOrchHandler(2, TEST_DEFAULT_ORCH, 'saturn.ms', 1000)
+      mockOrchHandler(2, TEST_DEFAULT_ORCH, TEST_ORIGIN_DOMAIN, 1000)
     ]
     const server = getMockServer(handlers)
     server.listen(MSW_SERVER_OPTS)
@@ -111,7 +111,7 @@ describe('Client Fallback', () => {
 
   test('Content Fallback fetches a cid properly', async (t) => {
     const handlers = [
-      mockOrchHandler(2, TEST_DEFAULT_ORCH, 'saturn.ms'),
+      mockOrchHandler(2, TEST_DEFAULT_ORCH, TEST_ORIGIN_DOMAIN),
       mockJWT(TEST_AUTH),
       mockSaturnOriginHandler(TEST_ORIGIN_DOMAIN, 0, true),
       ...mockNodesHandlers(2, TEST_ORIGIN_DOMAIN)
@@ -144,7 +144,7 @@ describe('Client Fallback', () => {
 
   test('Content Fallback fetches a cid properly with race', async (t) => {
     const handlers = [
-      mockOrchHandler(5, TEST_DEFAULT_ORCH, 'saturn.ms'),
+      mockOrchHandler(5, TEST_DEFAULT_ORCH, TEST_ORIGIN_DOMAIN),
       mockJWT(TEST_AUTH),
       mockSaturnOriginHandler(TEST_ORIGIN_DOMAIN, 0, true),
       ...mockNodesHandlers(5, TEST_ORIGIN_DOMAIN)
@@ -178,7 +178,7 @@ describe('Client Fallback', () => {
 
   test('Content Fallback with race fetches from consecutive nodes on failure', async (t) => {
     const handlers = [
-      mockOrchHandler(5, TEST_DEFAULT_ORCH, 'saturn.ms'),
+      mockOrchHandler(5, TEST_DEFAULT_ORCH, TEST_ORIGIN_DOMAIN),
       mockJWT(TEST_AUTH),
       mockSaturnOriginHandler(TEST_ORIGIN_DOMAIN, 0, true),
       ...mockNodesHandlers(5, TEST_ORIGIN_DOMAIN, 2)
@@ -204,6 +204,8 @@ describe('Client Fallback', () => {
     const actualContent = String.fromCharCode(...buffer)
     const expectedContent = 'hello world\n'
 
+    console.log('Logs', saturn.logs)
+
     assert.strictEqual(actualContent, expectedContent)
     server.close()
     mock.reset()
@@ -211,7 +213,7 @@ describe('Client Fallback', () => {
 
   test('should fetch content from the first node successfully', async () => {
     const handlers = [
-      mockOrchHandler(2, TEST_DEFAULT_ORCH, 'saturn.ms'),
+      mockOrchHandler(2, TEST_DEFAULT_ORCH, TEST_ORIGIN_DOMAIN),
       mockJWT(TEST_AUTH),
       ...mockNodesHandlers(2, TEST_ORIGIN_DOMAIN)
     ]
@@ -236,203 +238,203 @@ describe('Client Fallback', () => {
     mock.reset()
   })
 
-  test('should try all nodes and fail if all nodes fail', async () => {
-    const numNodes = 3
-    const handlers = [
-      mockOrchHandler(numNodes, TEST_DEFAULT_ORCH, 'saturn.ms'),
-      mockJWT(TEST_AUTH),
-      ...mockNodesHandlers(numNodes, TEST_ORIGIN_DOMAIN)
-    ]
+  // test('should try all nodes and fail if all nodes fail', async () => {
+  //   const numNodes = 3
+  //   const handlers = [
+  //     mockOrchHandler(numNodes, TEST_DEFAULT_ORCH, TEST_ORIGIN_DOMAIN),
+  //     mockJWT(TEST_AUTH),
+  //     ...mockNodesHandlers(numNodes, TEST_ORIGIN_DOMAIN)
+  //   ]
 
-    const server = getMockServer(handlers)
-    server.listen(MSW_SERVER_OPTS)
-    const saturn = new Saturn({ clientKey: CLIENT_KEY, clientId: 'test', experimental })
+  //   const server = getMockServer(handlers)
+  //   server.listen(MSW_SERVER_OPTS)
+  //   const saturn = new Saturn({ clientKey: CLIENT_KEY, clientId: 'test', experimental })
 
-    const fetchContentMock = mock.fn(async function * (cidPath, opts) { throw new Error('Fetch error') }) // eslint-disable-line
-    saturn.fetchContent = fetchContentMock
+  //   const fetchContentMock = mock.fn(async function * (cidPath, opts) { throw new Error('Fetch error') }) // eslint-disable-line
+  //   saturn.fetchContent = fetchContentMock
 
-    let error
-    try {
-      for await (const _ of saturn.fetchContentWithFallback('some-cid-path')) { // eslint-disable-line
-        // This loop body shouldn't be reached.
-      }
-    } catch (e) {
-      error = e
-    }
+  //   let error
+  //   try {
+  //     for await (const _ of saturn.fetchContentWithFallback('some-cid-path')) { // eslint-disable-line
+  //       // This loop body shouldn't be reached.
+  //     }
+  //   } catch (e) {
+  //     error = e
+  //   }
 
-    assert(error)
-    assert.strictEqual(error.message, 'All attempts to fetch content have failed. Last error: Fetch error')
-    assert.strictEqual(fetchContentMock.mock.calls.length, numNodes + 1)
-    mock.reset()
-    server.close()
-  })
+  //   assert(error)
+  //   assert.strictEqual(error.message, 'All attempts to fetch content have failed. Last error: Fetch error')
+  //   assert.strictEqual(fetchContentMock.mock.calls.length, numNodes + 1)
+  //   mock.reset()
+  //   server.close()
+  // })
 
-  test('Should abort fallback on 410s', async () => {
-    const numNodes = 3
-    const handlers = [
-      mockOrchHandler(numNodes, TEST_DEFAULT_ORCH, 'saturn.ms'),
-      mockJWT(TEST_AUTH),
-      ...mockNodesHandlers(numNodes, TEST_ORIGIN_DOMAIN, 3, HTTP_STATUS_GONE)
-    ]
+  // test('Should abort fallback on 410s', async () => {
+  //   const numNodes = 3
+  //   const handlers = [
+  //     mockOrchHandler(numNodes, TEST_DEFAULT_ORCH, TEST_ORIGIN_DOMAIN),
+  //     mockJWT(TEST_AUTH),
+  //     ...mockNodesHandlers(numNodes, TEST_ORIGIN_DOMAIN, 3, HTTP_STATUS_GONE)
+  //   ]
 
-    const server = getMockServer(handlers)
-    server.listen(MSW_SERVER_OPTS)
-    const saturn = new Saturn({ clientKey: CLIENT_KEY, clientId: 'test', experimental })
-    await saturn.loadNodesPromise
+  //   const server = getMockServer(handlers)
+  //   server.listen(MSW_SERVER_OPTS)
+  //   const saturn = new Saturn({ clientKey: CLIENT_KEY, clientId: 'test', experimental })
+  //   await saturn.loadNodesPromise
 
-    let error
-    try {
-      for await (const _ of saturn.fetchContentWithFallback('bafkreifjjcie6lypi6ny7amxnfftagclbuxndqonfipmb64f2km2devei4')) { // eslint-disable-line
-        // This loop body shouldn't be reached.
-      }
-    } catch (e) {
-      error = e
-    }
-    const logs = saturn.logs
+  //   let error
+  //   try {
+  //     for await (const _ of saturn.fetchContentWithFallback('bafkreifjjcie6lypi6ny7amxnfftagclbuxndqonfipmb64f2km2devei4')) { // eslint-disable-line
+  //       // This loop body shouldn't be reached.
+  //     }
+  //   } catch (e) {
+  //     error = e
+  //   }
+  //   const logs = saturn.logs
 
-    assert(error)
-    assert.strictEqual(logs.length, 1)
-    mock.reset()
-    server.close()
-  })
+  //   assert(error)
+  //   assert.strictEqual(logs.length, 1)
+  //   mock.reset()
+  //   server.close()
+  // })
 
-  test('Should abort fallback on specific errors', async () => {
-    const numNodes = 3
-    const handlers = [
-      mockOrchHandler(numNodes, TEST_DEFAULT_ORCH, 'saturn.ms'),
-      mockJWT(TEST_AUTH),
-      ...mockNodesHandlers(numNodes, TEST_ORIGIN_DOMAIN, 3, HTTP_STATUS_GONE)
-    ]
+  // test('Should abort fallback on specific errors', async () => {
+  //   const numNodes = 3
+  //   const handlers = [
+  //     mockOrchHandler(numNodes, TEST_DEFAULT_ORCH, TEST_ORIGIN_DOMAIN),
+  //     mockJWT(TEST_AUTH),
+  //     ...mockNodesHandlers(numNodes, TEST_ORIGIN_DOMAIN, 3, HTTP_STATUS_GONE)
+  //   ]
 
-    const server = getMockServer(handlers)
-    server.listen(MSW_SERVER_OPTS)
-    const saturn = new Saturn({ clientKey: CLIENT_KEY, clientId: 'test', experimental })
-    await saturn.loadNodesPromise
+  //   const server = getMockServer(handlers)
+  //   server.listen(MSW_SERVER_OPTS)
+  //   const saturn = new Saturn({ clientKey: CLIENT_KEY, clientId: 'test', experimental })
+  //   await saturn.loadNodesPromise
 
-    let callCount = 0
-    const fetchContentMock = mock.fn(async function * (cidPath, opts) {
-      callCount++
-      yield ''
-      throw new Error('file does not exist')
-    })
+  //   let callCount = 0
+  //   const fetchContentMock = mock.fn(async function * (cidPath, opts) {
+  //     callCount++
+  //     yield ''
+  //     throw new Error('file does not exist')
+  //   })
 
-    saturn.fetchContent = fetchContentMock
+  //   saturn.fetchContent = fetchContentMock
 
-    let error
-    try {
-      for await (const _ of saturn.fetchContentWithFallback('bafkreifjjcie6lypi6ny7amxnfftagclbuxndqonfipmb64f2km2devei4')) { // eslint-disable-line
-      }
-    } catch (e) {
-      error = e
-    }
+  //   let error
+  //   try {
+  //     for await (const _ of saturn.fetchContentWithFallback('bafkreifjjcie6lypi6ny7amxnfftagclbuxndqonfipmb64f2km2devei4')) { // eslint-disable-line
+  //     }
+  //   } catch (e) {
+  //     error = e
+  //   }
 
-    assert(error)
-    assert.strictEqual(callCount, 1)
-    mock.reset()
-    server.close()
-  })
-  test('Handles fallback with chunk overlap correctly', async () => {
-    const numNodes = 3
-    const handlers = [
-      mockOrchHandler(numNodes, TEST_DEFAULT_ORCH, 'saturn.ms'),
-      mockJWT(TEST_AUTH),
-      ...mockNodesHandlers(numNodes, TEST_ORIGIN_DOMAIN)
-    ]
+  //   assert(error)
+  //   assert.strictEqual(callCount, 1)
+  //   mock.reset()
+  //   server.close()
+  // })
+  // test('Handles fallback with chunk overlap correctly', async () => {
+  //   const numNodes = 3
+  //   const handlers = [
+  //     mockOrchHandler(numNodes, TEST_DEFAULT_ORCH, TEST_ORIGIN_DOMAIN),
+  //     mockJWT(TEST_AUTH),
+  //     ...mockNodesHandlers(numNodes, TEST_ORIGIN_DOMAIN)
+  //   ]
 
-    const server = getMockServer(handlers)
-    server.listen(MSW_SERVER_OPTS)
-    const saturn = new Saturn({ clientKey: CLIENT_KEY, clientId: 'test', experimental })
+  //   const server = getMockServer(handlers)
+  //   server.listen(MSW_SERVER_OPTS)
+  //   const saturn = new Saturn({ clientKey: CLIENT_KEY, clientId: 'test', experimental })
 
-    let callCount = 0
-    const fetchContentMock = mock.fn(async function * (cidPath, opts) {
-      callCount++
-      if (callCount === 1) {
-        throw new Error('First call error')
-      }
-      if (callCount === 2) {
-        yield Buffer.from('chunk1-overlap')
-        yield Buffer.from('chunk2')
-      }
-    })
+  //   let callCount = 0
+  //   const fetchContentMock = mock.fn(async function * (cidPath, opts) {
+  //     callCount++
+  //     if (callCount === 1) {
+  //       throw new Error('First call error')
+  //     }
+  //     if (callCount === 2) {
+  //       yield Buffer.from('chunk1-overlap')
+  //       yield Buffer.from('chunk2')
+  //     }
+  //   })
 
-    saturn.fetchContent = fetchContentMock
+  //   saturn.fetchContent = fetchContentMock
 
-    const content = saturn.fetchContentWithFallback('some-cid-path')
-    const buffer = await concatChunks(content)
-    const expectedContent = new Uint8Array([
-      ...Buffer.from('chunk1-overlap'),
-      ...Buffer.from('chunk2')
-    ])
+  //   const content = saturn.fetchContentWithFallback('some-cid-path')
+  //   const buffer = await concatChunks(content)
+  //   const expectedContent = new Uint8Array([
+  //     ...Buffer.from('chunk1-overlap'),
+  //     ...Buffer.from('chunk2')
+  //   ])
 
-    assert.deepEqual(buffer, expectedContent)
-    assert.strictEqual(fetchContentMock.mock.calls.length, 2)
-    server.close()
-    mock.reset()
-  })
+  //   assert.deepEqual(buffer, expectedContent)
+  //   assert.strictEqual(fetchContentMock.mock.calls.length, 2)
+  //   server.close()
+  //   mock.reset()
+  // })
 
-  test('should handle byte chunk overlaps correctly', async () => {
-    const numNodes = 3
-    const handlers = [
-      mockOrchHandler(numNodes, TEST_DEFAULT_ORCH, 'saturn.ms'),
-      mockJWT(TEST_AUTH),
-      ...mockNodesHandlers(numNodes, TEST_ORIGIN_DOMAIN)
-    ]
+  // test('should handle byte chunk overlaps correctly', async () => {
+  //   const numNodes = 3
+  //   const handlers = [
+  //     mockOrchHandler(numNodes, TEST_DEFAULT_ORCH, TEST_ORIGIN_DOMAIN),
+  //     mockJWT(TEST_AUTH),
+  //     ...mockNodesHandlers(numNodes, TEST_ORIGIN_DOMAIN)
+  //   ]
 
-    const server = getMockServer(handlers)
-    server.listen(MSW_SERVER_OPTS)
-    const saturn = new Saturn({ clientKey: CLIENT_KEY, clientId: 'test', experimental })
+  //   const server = getMockServer(handlers)
+  //   server.listen(MSW_SERVER_OPTS)
+  //   const saturn = new Saturn({ clientKey: CLIENT_KEY, clientId: 'test', experimental })
 
-    let callCount = 0
-    let fetchContentMock = mock.fn(async function * (cidPath, opts) {
-      callCount++
-      if (callCount === 1) {
-        yield Buffer.from('chunk1-overlap')
-        throw new Error('First call error')
-      }
-      if (callCount === 2) {
-        yield Buffer.from('chunk1-overlap')
-        yield Buffer.from('chunk2')
-      }
-    })
+  //   let callCount = 0
+  //   let fetchContentMock = mock.fn(async function * (cidPath, opts) {
+  //     callCount++
+  //     if (callCount === 1) {
+  //       yield Buffer.from('chunk1-overlap')
+  //       throw new Error('First call error')
+  //     }
+  //     if (callCount === 2) {
+  //       yield Buffer.from('chunk1-overlap')
+  //       yield Buffer.from('chunk2')
+  //     }
+  //   })
 
-    saturn.fetchContent = fetchContentMock
-    const expectedContent = new Uint8Array([
-      ...Buffer.from('chunk1-overlap'),
-      ...Buffer.from('chunk2')
-    ])
-    let content = saturn.fetchContentWithFallback('some-cid-path')
-    let buffer = await concatChunks(content)
+  //   saturn.fetchContent = fetchContentMock
+  //   const expectedContent = new Uint8Array([
+  //     ...Buffer.from('chunk1-overlap'),
+  //     ...Buffer.from('chunk2')
+  //   ])
+  //   let content = saturn.fetchContentWithFallback('some-cid-path')
+  //   let buffer = await concatChunks(content)
 
-    assert.deepEqual(buffer, expectedContent)
-    assert.strictEqual(fetchContentMock.mock.calls.length, 2)
+  //   assert.deepEqual(buffer, expectedContent)
+  //   assert.strictEqual(fetchContentMock.mock.calls.length, 2)
 
-    callCount = 0
-    fetchContentMock = mock.fn(async function * (cidPath, opts) {
-      callCount++
-      if (callCount === 1) {
-        yield Buffer.from('chunk1-')
-        throw new Error('First call error')
-      }
-      if (callCount === 2) {
-        yield Buffer.from('chunk1')
-        yield Buffer.from('-overlap')
-        throw new Error('Second call error')
-      }
-      if (callCount === 3) {
-        yield Buffer.from('chunk1-overlap')
-        yield Buffer.from('chunk2')
-      }
-    })
+  //   callCount = 0
+  //   fetchContentMock = mock.fn(async function * (cidPath, opts) {
+  //     callCount++
+  //     if (callCount === 1) {
+  //       yield Buffer.from('chunk1-')
+  //       throw new Error('First call error')
+  //     }
+  //     if (callCount === 2) {
+  //       yield Buffer.from('chunk1')
+  //       yield Buffer.from('-overlap')
+  //       throw new Error('Second call error')
+  //     }
+  //     if (callCount === 3) {
+  //       yield Buffer.from('chunk1-overlap')
+  //       yield Buffer.from('chunk2')
+  //     }
+  //   })
 
-    saturn.fetchContent = fetchContentMock
+  //   saturn.fetchContent = fetchContentMock
 
-    content = await saturn.fetchContentWithFallback('some-cid-path')
-    buffer = await concatChunks(content)
+  //   content = await saturn.fetchContentWithFallback('some-cid-path')
+  //   buffer = await concatChunks(content)
 
-    assert.deepEqual(buffer, expectedContent)
-    assert.strictEqual(fetchContentMock.mock.calls.length, 3)
+  //   assert.deepEqual(buffer, expectedContent)
+  //   assert.strictEqual(fetchContentMock.mock.calls.length, 3)
 
-    server.close()
-    mock.reset()
-  })
+  //   server.close()
+  //   mock.reset()
+  // })
 })

--- a/test/fallback.spec.js
+++ b/test/fallback.spec.js
@@ -5,13 +5,20 @@ import { describe, mock, test } from 'node:test'
 import { Saturn } from '#src/index.js'
 import { concatChunks, generateNodes, getMockServer, HTTP_STATUS_GONE, mockJWT, mockNodesHandlers, mockOrchHandler, mockSaturnOriginHandler, MSW_SERVER_OPTS } from './test-utils.js'
 
-const TEST_DEFAULT_ORCH = 'https://orchestrator.strn.pl/nodes'
+const TEST_DEFAULT_ORCH = 'https://orchestrator.strn.pl.test/nodes'
 const TEST_NODES_LIST_KEY = 'saturn-nodes'
-const TEST_AUTH = 'https://fz3dyeyxmebszwhuiky7vggmsu0rlkoy.lambda-url.us-west-2.on.aws/'
-const TEST_ORIGIN_DOMAIN = 'https://l1s.saturn.ms'
+const TEST_AUTH = 'https://auth.test/'
+const TEST_ORIGIN_DOMAIN = 'l1s.saturn.test'
 const CLIENT_KEY = 'key'
 
-const experimental = true
+const options = {
+  cdnURL: TEST_ORIGIN_DOMAIN,
+  orchURL: TEST_DEFAULT_ORCH,
+  authURL: TEST_AUTH,
+  experimental: true,
+  clientKey: CLIENT_KEY,
+  clientId: 'test'
+}
 
 describe('Client Fallback', () => {
   test('Nodes are loaded from the orchestrator if no storage is passed', async (t) => {
@@ -24,7 +31,7 @@ describe('Client Fallback', () => {
     const expectedNodes = generateNodes(2, TEST_ORIGIN_DOMAIN)
 
     // No Storage is injected
-    const saturn = new Saturn({ clientKey: CLIENT_KEY, experimental })
+    const saturn = new Saturn({ ...options })
     const mockOpts = { orchURL: TEST_DEFAULT_ORCH }
 
     await saturn._loadNodes(mockOpts)
@@ -53,7 +60,7 @@ describe('Client Fallback', () => {
     t.mock.method(mockStorage, 'get')
     t.mock.method(mockStorage, 'set')
 
-    const saturn = new Saturn({ storage: mockStorage, clientKey: CLIENT_KEY, experimental })
+    const saturn = new Saturn({ storage: mockStorage, ...options })
 
     // Mocking options
     const mockOpts = { orchURL: TEST_DEFAULT_ORCH }
@@ -90,7 +97,7 @@ describe('Client Fallback', () => {
     t.mock.method(mockStorage, 'get')
     t.mock.method(mockStorage, 'set')
 
-    const saturn = new Saturn({ storage: mockStorage, clientKey: CLIENT_KEY, experimental })
+    const saturn = new Saturn({ storage: mockStorage, ...options })
 
     // Mocking options
     const mockOpts = { orchURL: TEST_DEFAULT_ORCH }
@@ -129,7 +136,7 @@ describe('Client Fallback', () => {
     t.mock.method(mockStorage, 'get')
     t.mock.method(mockStorage, 'set')
 
-    const saturn = new Saturn({ storage: mockStorage, clientKey: CLIENT_KEY, clientId: 'test', experimental })
+    const saturn = new Saturn({ storage: mockStorage, ...options })
 
     const cid = saturn.fetchContentWithFallback('bafkreifjjcie6lypi6ny7amxnfftagclbuxndqonfipmb64f2km2devei4')
 
@@ -162,8 +169,7 @@ describe('Client Fallback', () => {
     t.mock.method(mockStorage, 'get')
     t.mock.method(mockStorage, 'set')
 
-    const saturn = new Saturn({ storage: mockStorage, clientKey: CLIENT_KEY, clientId: 'test', experimental })
-    // const origins =
+    const saturn = new Saturn({ ...options })
 
     const cid = saturn.fetchContentWithFallback('bafkreifjjcie6lypi6ny7amxnfftagclbuxndqonfipmb64f2km2devei4', { raceNodes: true })
 
@@ -196,15 +202,13 @@ describe('Client Fallback', () => {
     t.mock.method(mockStorage, 'get')
     t.mock.method(mockStorage, 'set')
 
-    const saturn = new Saturn({ storage: mockStorage, clientKey: CLIENT_KEY, clientId: 'test', experimental })
+    const saturn = new Saturn({ storage: mockStorage, ...options })
 
     const cid = saturn.fetchContentWithFallback('bafkreifjjcie6lypi6ny7amxnfftagclbuxndqonfipmb64f2km2devei4', { raceNodes: true })
 
     const buffer = await concatChunks(cid)
     const actualContent = String.fromCharCode(...buffer)
     const expectedContent = 'hello world\n'
-
-    console.log('Logs', saturn.logs)
 
     assert.strictEqual(actualContent, expectedContent)
     server.close()
@@ -220,7 +224,7 @@ describe('Client Fallback', () => {
 
     const server = getMockServer(handlers)
     server.listen(MSW_SERVER_OPTS)
-    const saturn = new Saturn({ clientKey: CLIENT_KEY, clientId: 'test', experimental })
+    const saturn = new Saturn({ ...options })
 
     const fetchContentMock = mock.fn(async function * (cidPath, opts) {
       yield Buffer.from('chunk1')
@@ -238,203 +242,203 @@ describe('Client Fallback', () => {
     mock.reset()
   })
 
-  // test('should try all nodes and fail if all nodes fail', async () => {
-  //   const numNodes = 3
-  //   const handlers = [
-  //     mockOrchHandler(numNodes, TEST_DEFAULT_ORCH, TEST_ORIGIN_DOMAIN),
-  //     mockJWT(TEST_AUTH),
-  //     ...mockNodesHandlers(numNodes, TEST_ORIGIN_DOMAIN)
-  //   ]
+  test('should try all nodes and fail if all nodes fail', async () => {
+    const numNodes = 3
+    const handlers = [
+      mockOrchHandler(numNodes, TEST_DEFAULT_ORCH, TEST_ORIGIN_DOMAIN),
+      mockJWT(TEST_AUTH),
+      ...mockNodesHandlers(numNodes, TEST_ORIGIN_DOMAIN)
+    ]
 
-  //   const server = getMockServer(handlers)
-  //   server.listen(MSW_SERVER_OPTS)
-  //   const saturn = new Saturn({ clientKey: CLIENT_KEY, clientId: 'test', experimental })
+    const server = getMockServer(handlers)
+    server.listen(MSW_SERVER_OPTS)
+    const saturn = new Saturn({ ...options })
 
-  //   const fetchContentMock = mock.fn(async function * (cidPath, opts) { throw new Error('Fetch error') }) // eslint-disable-line
-  //   saturn.fetchContent = fetchContentMock
+    const fetchContentMock = mock.fn(async function * (cidPath, opts) { throw new Error('Fetch error') }) // eslint-disable-line
+    saturn.fetchContent = fetchContentMock
 
-  //   let error
-  //   try {
-  //     for await (const _ of saturn.fetchContentWithFallback('some-cid-path')) { // eslint-disable-line
-  //       // This loop body shouldn't be reached.
-  //     }
-  //   } catch (e) {
-  //     error = e
-  //   }
+    let error
+    try {
+      for await (const _ of saturn.fetchContentWithFallback('some-cid-path')) { // eslint-disable-line
+        // This loop body shouldn't be reached.
+      }
+    } catch (e) {
+      error = e
+    }
 
-  //   assert(error)
-  //   assert.strictEqual(error.message, 'All attempts to fetch content have failed. Last error: Fetch error')
-  //   assert.strictEqual(fetchContentMock.mock.calls.length, numNodes + 1)
-  //   mock.reset()
-  //   server.close()
-  // })
+    assert(error)
+    assert.strictEqual(error.message, 'All attempts to fetch content have failed. Last error: Fetch error')
+    assert.strictEqual(fetchContentMock.mock.calls.length, numNodes + 1)
+    mock.reset()
+    server.close()
+  })
 
-  // test('Should abort fallback on 410s', async () => {
-  //   const numNodes = 3
-  //   const handlers = [
-  //     mockOrchHandler(numNodes, TEST_DEFAULT_ORCH, TEST_ORIGIN_DOMAIN),
-  //     mockJWT(TEST_AUTH),
-  //     ...mockNodesHandlers(numNodes, TEST_ORIGIN_DOMAIN, 3, HTTP_STATUS_GONE)
-  //   ]
+  test('Should abort fallback on 410s', async () => {
+    const numNodes = 3
+    const handlers = [
+      mockOrchHandler(numNodes, TEST_DEFAULT_ORCH, TEST_ORIGIN_DOMAIN),
+      mockJWT(TEST_AUTH),
+      ...mockNodesHandlers(numNodes, TEST_ORIGIN_DOMAIN, 3, HTTP_STATUS_GONE)
+    ]
 
-  //   const server = getMockServer(handlers)
-  //   server.listen(MSW_SERVER_OPTS)
-  //   const saturn = new Saturn({ clientKey: CLIENT_KEY, clientId: 'test', experimental })
-  //   await saturn.loadNodesPromise
+    const server = getMockServer(handlers)
+    server.listen(MSW_SERVER_OPTS)
+    const saturn = new Saturn({ ...options })
+    await saturn.loadNodesPromise
 
-  //   let error
-  //   try {
-  //     for await (const _ of saturn.fetchContentWithFallback('bafkreifjjcie6lypi6ny7amxnfftagclbuxndqonfipmb64f2km2devei4')) { // eslint-disable-line
-  //       // This loop body shouldn't be reached.
-  //     }
-  //   } catch (e) {
-  //     error = e
-  //   }
-  //   const logs = saturn.logs
+    let error
+    try {
+      for await (const _ of saturn.fetchContentWithFallback('bafkreifjjcie6lypi6ny7amxnfftagclbuxndqonfipmb64f2km2devei4')) { // eslint-disable-line
+        // This loop body shouldn't be reached.
+      }
+    } catch (e) {
+      error = e
+    }
+    const logs = saturn.logs
 
-  //   assert(error)
-  //   assert.strictEqual(logs.length, 1)
-  //   mock.reset()
-  //   server.close()
-  // })
+    assert(error)
+    assert.strictEqual(logs.length, 1)
+    mock.reset()
+    server.close()
+  })
 
-  // test('Should abort fallback on specific errors', async () => {
-  //   const numNodes = 3
-  //   const handlers = [
-  //     mockOrchHandler(numNodes, TEST_DEFAULT_ORCH, TEST_ORIGIN_DOMAIN),
-  //     mockJWT(TEST_AUTH),
-  //     ...mockNodesHandlers(numNodes, TEST_ORIGIN_DOMAIN, 3, HTTP_STATUS_GONE)
-  //   ]
+  test('Should abort fallback on specific errors', async () => {
+    const numNodes = 3
+    const handlers = [
+      mockOrchHandler(numNodes, TEST_DEFAULT_ORCH, TEST_ORIGIN_DOMAIN),
+      mockJWT(TEST_AUTH),
+      ...mockNodesHandlers(numNodes, TEST_ORIGIN_DOMAIN, 3, HTTP_STATUS_GONE)
+    ]
 
-  //   const server = getMockServer(handlers)
-  //   server.listen(MSW_SERVER_OPTS)
-  //   const saturn = new Saturn({ clientKey: CLIENT_KEY, clientId: 'test', experimental })
-  //   await saturn.loadNodesPromise
+    const server = getMockServer(handlers)
+    server.listen(MSW_SERVER_OPTS)
+    const saturn = new Saturn({ ...options })
+    await saturn.loadNodesPromise
 
-  //   let callCount = 0
-  //   const fetchContentMock = mock.fn(async function * (cidPath, opts) {
-  //     callCount++
-  //     yield ''
-  //     throw new Error('file does not exist')
-  //   })
+    let callCount = 0
+    const fetchContentMock = mock.fn(async function * (cidPath, opts) {
+      callCount++
+      yield ''
+      throw new Error('file does not exist')
+    })
 
-  //   saturn.fetchContent = fetchContentMock
+    saturn.fetchContent = fetchContentMock
 
-  //   let error
-  //   try {
-  //     for await (const _ of saturn.fetchContentWithFallback('bafkreifjjcie6lypi6ny7amxnfftagclbuxndqonfipmb64f2km2devei4')) { // eslint-disable-line
-  //     }
-  //   } catch (e) {
-  //     error = e
-  //   }
+    let error
+    try {
+      for await (const _ of saturn.fetchContentWithFallback('bafkreifjjcie6lypi6ny7amxnfftagclbuxndqonfipmb64f2km2devei4')) { // eslint-disable-line
+      }
+    } catch (e) {
+      error = e
+    }
 
-  //   assert(error)
-  //   assert.strictEqual(callCount, 1)
-  //   mock.reset()
-  //   server.close()
-  // })
-  // test('Handles fallback with chunk overlap correctly', async () => {
-  //   const numNodes = 3
-  //   const handlers = [
-  //     mockOrchHandler(numNodes, TEST_DEFAULT_ORCH, TEST_ORIGIN_DOMAIN),
-  //     mockJWT(TEST_AUTH),
-  //     ...mockNodesHandlers(numNodes, TEST_ORIGIN_DOMAIN)
-  //   ]
+    assert(error)
+    assert.strictEqual(callCount, 1)
+    mock.reset()
+    server.close()
+  })
+  test('Handles fallback with chunk overlap correctly', async () => {
+    const numNodes = 3
+    const handlers = [
+      mockOrchHandler(numNodes, TEST_DEFAULT_ORCH, TEST_ORIGIN_DOMAIN),
+      mockJWT(TEST_AUTH),
+      ...mockNodesHandlers(numNodes, TEST_ORIGIN_DOMAIN)
+    ]
 
-  //   const server = getMockServer(handlers)
-  //   server.listen(MSW_SERVER_OPTS)
-  //   const saturn = new Saturn({ clientKey: CLIENT_KEY, clientId: 'test', experimental })
+    const server = getMockServer(handlers)
+    server.listen(MSW_SERVER_OPTS)
+    const saturn = new Saturn({ ...options })
 
-  //   let callCount = 0
-  //   const fetchContentMock = mock.fn(async function * (cidPath, opts) {
-  //     callCount++
-  //     if (callCount === 1) {
-  //       throw new Error('First call error')
-  //     }
-  //     if (callCount === 2) {
-  //       yield Buffer.from('chunk1-overlap')
-  //       yield Buffer.from('chunk2')
-  //     }
-  //   })
+    let callCount = 0
+    const fetchContentMock = mock.fn(async function * (cidPath, opts) {
+      callCount++
+      if (callCount === 1) {
+        throw new Error('First call error')
+      }
+      if (callCount === 2) {
+        yield Buffer.from('chunk1-overlap')
+        yield Buffer.from('chunk2')
+      }
+    })
 
-  //   saturn.fetchContent = fetchContentMock
+    saturn.fetchContent = fetchContentMock
 
-  //   const content = saturn.fetchContentWithFallback('some-cid-path')
-  //   const buffer = await concatChunks(content)
-  //   const expectedContent = new Uint8Array([
-  //     ...Buffer.from('chunk1-overlap'),
-  //     ...Buffer.from('chunk2')
-  //   ])
+    const content = saturn.fetchContentWithFallback('some-cid-path')
+    const buffer = await concatChunks(content)
+    const expectedContent = new Uint8Array([
+      ...Buffer.from('chunk1-overlap'),
+      ...Buffer.from('chunk2')
+    ])
 
-  //   assert.deepEqual(buffer, expectedContent)
-  //   assert.strictEqual(fetchContentMock.mock.calls.length, 2)
-  //   server.close()
-  //   mock.reset()
-  // })
+    assert.deepEqual(buffer, expectedContent)
+    assert.strictEqual(fetchContentMock.mock.calls.length, 2)
+    server.close()
+    mock.reset()
+  })
 
-  // test('should handle byte chunk overlaps correctly', async () => {
-  //   const numNodes = 3
-  //   const handlers = [
-  //     mockOrchHandler(numNodes, TEST_DEFAULT_ORCH, TEST_ORIGIN_DOMAIN),
-  //     mockJWT(TEST_AUTH),
-  //     ...mockNodesHandlers(numNodes, TEST_ORIGIN_DOMAIN)
-  //   ]
+  test('should handle byte chunk overlaps correctly', async () => {
+    const numNodes = 3
+    const handlers = [
+      mockOrchHandler(numNodes, TEST_DEFAULT_ORCH, TEST_ORIGIN_DOMAIN),
+      mockJWT(TEST_AUTH),
+      ...mockNodesHandlers(numNodes, TEST_ORIGIN_DOMAIN)
+    ]
 
-  //   const server = getMockServer(handlers)
-  //   server.listen(MSW_SERVER_OPTS)
-  //   const saturn = new Saturn({ clientKey: CLIENT_KEY, clientId: 'test', experimental })
+    const server = getMockServer(handlers)
+    server.listen(MSW_SERVER_OPTS)
+    const saturn = new Saturn({ ...options })
 
-  //   let callCount = 0
-  //   let fetchContentMock = mock.fn(async function * (cidPath, opts) {
-  //     callCount++
-  //     if (callCount === 1) {
-  //       yield Buffer.from('chunk1-overlap')
-  //       throw new Error('First call error')
-  //     }
-  //     if (callCount === 2) {
-  //       yield Buffer.from('chunk1-overlap')
-  //       yield Buffer.from('chunk2')
-  //     }
-  //   })
+    let callCount = 0
+    let fetchContentMock = mock.fn(async function * (cidPath, opts) {
+      callCount++
+      if (callCount === 1) {
+        yield Buffer.from('chunk1-overlap')
+        throw new Error('First call error')
+      }
+      if (callCount === 2) {
+        yield Buffer.from('chunk1-overlap')
+        yield Buffer.from('chunk2')
+      }
+    })
 
-  //   saturn.fetchContent = fetchContentMock
-  //   const expectedContent = new Uint8Array([
-  //     ...Buffer.from('chunk1-overlap'),
-  //     ...Buffer.from('chunk2')
-  //   ])
-  //   let content = saturn.fetchContentWithFallback('some-cid-path')
-  //   let buffer = await concatChunks(content)
+    saturn.fetchContent = fetchContentMock
+    const expectedContent = new Uint8Array([
+      ...Buffer.from('chunk1-overlap'),
+      ...Buffer.from('chunk2')
+    ])
+    let content = saturn.fetchContentWithFallback('some-cid-path')
+    let buffer = await concatChunks(content)
 
-  //   assert.deepEqual(buffer, expectedContent)
-  //   assert.strictEqual(fetchContentMock.mock.calls.length, 2)
+    assert.deepEqual(buffer, expectedContent)
+    assert.strictEqual(fetchContentMock.mock.calls.length, 2)
 
-  //   callCount = 0
-  //   fetchContentMock = mock.fn(async function * (cidPath, opts) {
-  //     callCount++
-  //     if (callCount === 1) {
-  //       yield Buffer.from('chunk1-')
-  //       throw new Error('First call error')
-  //     }
-  //     if (callCount === 2) {
-  //       yield Buffer.from('chunk1')
-  //       yield Buffer.from('-overlap')
-  //       throw new Error('Second call error')
-  //     }
-  //     if (callCount === 3) {
-  //       yield Buffer.from('chunk1-overlap')
-  //       yield Buffer.from('chunk2')
-  //     }
-  //   })
+    callCount = 0
+    fetchContentMock = mock.fn(async function * (cidPath, opts) {
+      callCount++
+      if (callCount === 1) {
+        yield Buffer.from('chunk1-')
+        throw new Error('First call error')
+      }
+      if (callCount === 2) {
+        yield Buffer.from('chunk1')
+        yield Buffer.from('-overlap')
+        throw new Error('Second call error')
+      }
+      if (callCount === 3) {
+        yield Buffer.from('chunk1-overlap')
+        yield Buffer.from('chunk2')
+      }
+    })
 
-  //   saturn.fetchContent = fetchContentMock
+    saturn.fetchContent = fetchContentMock
 
-  //   content = await saturn.fetchContentWithFallback('some-cid-path')
-  //   buffer = await concatChunks(content)
+    content = await saturn.fetchContentWithFallback('some-cid-path')
+    buffer = await concatChunks(content)
 
-  //   assert.deepEqual(buffer, expectedContent)
-  //   assert.strictEqual(fetchContentMock.mock.calls.length, 3)
+    assert.deepEqual(buffer, expectedContent)
+    assert.strictEqual(fetchContentMock.mock.calls.length, 3)
 
-  //   server.close()
-  //   mock.reset()
-  // })
+    server.close()
+    mock.reset()
+  })
 })

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -52,6 +52,7 @@ export function generateNodes (count, originDomain) {
  */
 export function mockSaturnOriginHandler (cdnURL, delay = 0, error = false) {
   cdnURL = addHttpPrefix(cdnURL)
+  cdnURL = `${cdnURL}/ipfs/:cid`
   return rest.get(cdnURL, (req, res, ctx) => {
     if (error) {
       throw Error('Simulated Error')

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -33,6 +33,7 @@ export function generateNodes (count, originDomain) {
     const nodeIp = `node${i}`
     const node = {
       ip: nodeIp,
+      id: nodeIp,
       weight: 50,
       distance: 100,
       url: `https://${nodeIp}.${originDomain}`


### PR DESCRIPTION
## Changes:
- When making requests directly to nodes, we now have the ability to log their ids even if the initial fetch fails without response. 