### PR TITLE
feat: add customer origin url fallback

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -28,7 +28,7 @@ export class Saturn {
    * @param {number} [opts.connectTimeout=5000]
    * @param {number} [opts.downloadTimeout=0]
    * @param {string} [opts.orchURL]
-   * @param {string} [opts.originURL]
+   * @param {string} [opts.customerFallbackURL]
    * @param {number} [opts.fallbackLimit]
    * @param {boolean} [opts.experimental]
    * @param {import('./storage/index.js').Storage} [opts.storage]
@@ -245,7 +245,7 @@ export class Saturn {
    * @param {object} [opts={}]
    * @param {('car'|'raw')} [opts.format]
    * @param {boolean} [opts.raceNodes]
-   * @param {string} [opts.originURL]
+   * @param {string} [opts.customerFallbackURL]
    * @param {number} [opts.connectTimeout=5000]
    * @param {number} [opts.downloadTimeout=0]
    * @returns {Promise<AsyncIterable<Uint8Array>>}
@@ -323,7 +323,7 @@ export class Saturn {
     }
 
     if (lastError) {
-      const originUrl = opts.originURL ?? this.opts.originURL
+      const originUrl = opts.customerFallbackURL ?? this.opts.customerFallbackURL
       // Use customer origin if cid is not retrievable by lassie.
       if (originUrl) {
         opts.nodes = Array({ url: originUrl })

--- a/src/client.js
+++ b/src/client.js
@@ -301,11 +301,8 @@ export class Saturn {
     let fallbackCount = 0
     const nodes = this.nodes
     for (let i = 0; i < nodes.length; i++) {
-      if (skipNodes) {
+      if (fallbackCount > this.opts.fallbackLimit || skipNodes) {
         break
-      }
-      if (fallbackCount > this.opts.fallbackLimit) {
-        return
       }
       if (opts.raceNodes) {
         opts.nodes = nodes.slice(i, i + Saturn.defaultRaceCount)

--- a/src/client.js
+++ b/src/client.js
@@ -160,7 +160,7 @@ export class Saturn {
    * @returns {Promise<object>}
    */
   async fetchCID (cidPath, opts = {}) {
-    const options = Object.assign({}, this.config, { format: 'car '} opts)
+    const options = Object.assign({}, this.config, { format: 'car ' }, opts)
     if (!opts.originFallback) {
       const [cid] = (cidPath ?? '').split('/')
       CID.parse(cid)
@@ -306,7 +306,6 @@ export class Saturn {
         yield * fetchContent()
         return
       } catch (err) {
-        console.log(err)
         lastError = err
         if (err.res?.status === 410 || isErrorUnavoidable(err)) {
           break

--- a/src/client.js
+++ b/src/client.js
@@ -22,19 +22,19 @@ export class Saturn {
   static defaultRaceCount = 3
   /**
    *
-   * @param {object} [opts={}]
-   * @param {string} [opts.clientKey]
-   * @param {string} [opts.clientId=randomUUID()]
-   * @param {string} [opts.cdnURL=saturn.ms]
-   * @param {number} [opts.connectTimeout=5000]
-   * @param {number} [opts.downloadTimeout=0]
-   * @param {string} [opts.orchURL]
-   * @param {string} [opts.customerFallbackURL]
-   * @param {number} [opts.fallbackLimit]
-   * @param {boolean} [opts.experimental]
-   * @param {import('./storage/index.js').Storage} [opts.storage]
+   * @param {object} [config={}]
+   * @param {string} [config.clientKey]
+   * @param {string} [config.clientId=randomUUID()]
+   * @param {string} [config.cdnURL=saturn.ms]
+   * @param {number} [config.connectTimeout=5000]
+   * @param {number} [config.downloadTimeout=0]
+   * @param {string} [config.orchURL]
+   * @param {string} [config.customerFallbackURL]
+   * @param {number} [config.fallbackLimit]
+   * @param {boolean} [config.experimental]
+   * @param {import('./storage/index.js').Storage} [config.storage]
    */
-  constructor (opts = {}) {
+  constructor (config = {}) {
     this.config = Object.assign({}, {
       clientId: randomUUID(),
       cdnURL: 'l1s.saturn.ms',
@@ -44,7 +44,7 @@ export class Saturn {
       fallbackLimit: 5,
       connectTimeout: 5_000,
       downloadTimeout: 0
-    }, opts)
+    }, config)
 
     if (!this.config.clientKey) {
       throw new Error('clientKey is required')
@@ -69,7 +69,6 @@ export class Saturn {
    */
   async fetchCIDWithRace (cidPath, opts = {}) {
     const options = Object.assign({}, this.config, { format: 'car ' }, opts)
-
     if (!opts.originFallback) {
       const [cid] = (cidPath ?? '').split('/')
       CID.parse(cid)
@@ -160,7 +159,7 @@ export class Saturn {
    * @returns {Promise<object>}
    */
   async fetchCID (cidPath, opts = {}) {
-    const options = Object.assign({}, this.config, { format: 'car ' }, opts)
+    const options = Object.assign({}, this.config, { format: 'car' }, opts)
     if (!opts.originFallback) {
       const [cid] = (cidPath ?? '').split('/')
       CID.parse(cid)

--- a/src/client.js
+++ b/src/client.js
@@ -68,7 +68,7 @@ export class Saturn {
    * @returns {Promise<object>}
    */
   async fetchCIDWithRace (cidPath, opts = {}) {
-    const options = Object.assign({}, this.config, { format: 'car ' }, opts)
+    const options = Object.assign({}, this.config, { format: 'car' }, opts)
     if (!opts.originFallback) {
       const [cid] = (cidPath ?? '').split('/')
       CID.parse(cid)
@@ -163,7 +163,7 @@ export class Saturn {
     if (!opts.originFallback) {
       const [cid] = (cidPath ?? '').split('/')
       CID.parse(cid)
-      const jwt = await getJWT(options, this.storage)
+      const jwt = await getJWT(this.config, this.storage)
       options.jwt = jwt
     }
 

--- a/src/client.js
+++ b/src/client.js
@@ -261,10 +261,9 @@ export class Saturn {
       throw new Error(`All attempts to fetch content have failed. Last error: ${lastError.message}`)
     }
 
-    const fetchContent = async function * (options) {
+    const fetchContent = async function * () {
       let byteCount = 0
-      const fetchOptions = Object.assign(opts, options)
-      const byteChunks = await this.fetchContent(cidPath, fetchOptions)
+      const byteChunks = await this.fetchContent(cidPath, opts)
       for await (const chunk of byteChunks) {
         // avoid sending duplicate chunks
         if (byteCount < byteCountCheckpoint) {

--- a/src/client.js
+++ b/src/client.js
@@ -14,6 +14,7 @@ import { isErrorUnavoidable } from './utils/errors.js'
 const MAX_NODE_WEIGHT = 100
 /**
  * @typedef {import('./types.js').Node} Node
+ * @typedef {import('./types.js').FetchOptions} FetchOptions
  */
 
 export class Saturn {
@@ -63,11 +64,7 @@ export class Saturn {
   /**
    *
    * @param {string} cidPath
-   * @param {object} [opts={}]
-   * @param {Node[]} [opts.nodes]
-   * @param {('car'|'raw')} [opts.format]
-   * @param {number} [opts.connectTimeout=5000]
-   * @param {number} [opts.downloadTimeout=0]
+   * @param {FetchOptions} [opts={}]
    * @returns {Promise<object>}
    */
   async fetchCIDWithRace (cidPath, opts = {}) {
@@ -157,11 +154,7 @@ export class Saturn {
   /**
    *
    * @param {string} cidPath
-   * @param {object} [opts={}]
-   * @param {('car'|'raw')} [opts.format]
-   * @param {Node[]} [opts.nodes]
-   * @param {number} [opts.connectTimeout=5000]
-   * @param {number} [opts.downloadTimeout=0]
+   * @param {FetchOptions} [opts={}]
    * @returns {Promise<object>}
    */
   async fetchCID (cidPath, opts = {}) {
@@ -242,12 +235,7 @@ export class Saturn {
   /**
    *
    * @param {string} cidPath
-   * @param {object} [opts={}]
-   * @param {('car'|'raw')} [opts.format]
-   * @param {boolean} [opts.raceNodes]
-   * @param {string} [opts.customerFallbackURL]
-   * @param {number} [opts.connectTimeout=5000]
-   * @param {number} [opts.downloadTimeout=0]
+   * @param {FetchOptions} [opts={}]
    * @returns {Promise<AsyncIterable<Uint8Array>>}
    */
   async * fetchContentWithFallback (cidPath, opts = {}) {
@@ -341,11 +329,7 @@ export class Saturn {
   /**
    *
    * @param {string} cidPath
-   * @param {object} [opts={}]
-   * @param {('car'|'raw')} [opts.format]
-   * @param {boolean} [opts.raceNodes]
-   * @param {number} [opts.connectTimeout=5000]
-   * @param {number} [opts.downloadTimeout=0]
+   * @param {FetchOptions} [opts={}]
    * @returns {Promise<AsyncIterable<Uint8Array>>}
    */
   async * fetchContent (cidPath, opts = {}) {
@@ -386,11 +370,7 @@ export class Saturn {
   /**
    *
    * @param {string} cidPath
-   * @param {object} [opts={}]
-   * @param {('car'|'raw')} [opts.format]
-   * @param {boolean} [opts.raceNodes]
-   * @param {number} [opts.connectTimeout=5000]
-   * @param {number} [opts.downloadTimeout=0]
+   * @param {FetchOptions} [opts={}]
    * @returns {Promise<Uint8Array>}
    */
   async fetchContentBuffer (cidPath, opts = {}) {

--- a/src/types.js
+++ b/src/types.js
@@ -12,4 +12,17 @@
  * @property {string} url
  */
 
+/**
+ * Common options for fetch functions.
+ *
+ * @typedef {object} FetchOptions
+ * @property {Node[]} [nodes] - An array of nodes.
+ * @property {('car'|'raw')} [format] - The format of the fetched content.
+ * @property {boolean} [originFallback] - Is this a fallback to the customer origin
+ * @property {boolean} [raceNodes] - Does the fetch race multiple nodes on requests.
+ * @property {string} [customerFallbackURL] - Customer Origin that is a fallback.
+ * @property {number} [connectTimeout=5000] - Connection timeout in milliseconds.
+ * @property {number} [downloadTimeout=0] - Download timeout in milliseconds.
+ */
+
 export {}

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -19,7 +19,8 @@ export function isErrorUnavoidable (error) {
     /file does not exist/,
     /Cannot read properties of undefined \(reading '([^']+)'\)/,
     /([a-zA-Z_.]+) is undefined/,
-    /undefined is not an object \(evaluating '([^']+)'\)/
+    /undefined is not an object \(evaluating '([^']+)'\)/,
+    /all retrievals failed/
   ]
 
   for (const pattern of errorPatterns) {

--- a/test/fallback.spec.js
+++ b/test/fallback.spec.js
@@ -9,7 +9,7 @@ const TEST_DEFAULT_ORCH = 'https://orchestrator.strn.pl.test/nodes'
 const TEST_NODES_LIST_KEY = 'saturn-nodes'
 const TEST_AUTH = 'https://auth.test/'
 const TEST_ORIGIN_DOMAIN = 'l1s.saturn.test'
-const TEST_CUSTOMER_ORIGIN = 'customer.test'
+const TEST_CUSTOMER_ORIGIN = 'customer.test/ipfs/bafkreifjjcie6lypi6ny7amxnfftagclbuxndqonfipmb64f2km2devei4'
 const CLIENT_KEY = 'key'
 
 const options = {
@@ -299,7 +299,7 @@ describe('Client Fallback', () => {
 
     const saturn = new Saturn({ storage: mockStorage, customerFallbackURL: TEST_CUSTOMER_ORIGIN, ...options })
 
-    const cid = saturn.fetchContentWithFallback('bafkreifjjcie6lypi6ny7amxnfftagclbuxndqonfipmb64f2km2devei4', { raceNodes: true })
+    const cid = saturn.fetchContentWithFallback(TEST_CUSTOMER_ORIGIN, { raceNodes: true })
 
     const buffer = await concatChunks(cid)
     const actualContent = String.fromCharCode(...buffer)

--- a/test/fallback.spec.js
+++ b/test/fallback.spec.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { describe, mock, test } from 'node:test'
 
 import { Saturn } from '#src/index.js'
-import { concatChunks, generateNodes, getMockServer, HTTP_STATUS_GONE, HTTP_STATUS_TIMEOUT, mockJWT, mockNodesHandlers, mockOrchHandler, mockOriginHandler, MSW_SERVER_OPTS } from './test-utils.js'
+import { concatChunks, generateNodes, getMockServer, HTTP_STATUS_GONE, HTTP_STATUS_TIMEOUT, mockFlatFileOriginHandler, mockJWT, mockNodesHandlers, mockOrchHandler, mockOriginHandler, MSW_SERVER_OPTS } from './test-utils.js'
 
 const TEST_DEFAULT_ORCH = 'https://orchestrator.strn.pl.test/nodes'
 const TEST_NODES_LIST_KEY = 'saturn-nodes'
@@ -280,7 +280,7 @@ describe('Client Fallback', () => {
       mockOrchHandler(numNodes, TEST_DEFAULT_ORCH, TEST_ORIGIN_DOMAIN),
       mockJWT(TEST_AUTH),
       mockOriginHandler(TEST_ORIGIN_DOMAIN, 0, true),
-      mockOriginHandler(TEST_CUSTOMER_ORIGIN, 0, false),
+      mockFlatFileOriginHandler(TEST_CUSTOMER_ORIGIN, 0, false),
       ...mockNodesHandlers(numNodes, TEST_ORIGIN_DOMAIN, numNodes, HTTP_STATUS_TIMEOUT)
     ]
 
@@ -303,9 +303,10 @@ describe('Client Fallback', () => {
 
     const buffer = await concatChunks(cid)
     const actualContent = String.fromCharCode(...buffer)
-    const expectedContent = 'hello world\n'
+    const jsonContent = JSON.parse(actualContent)
+    const expectedContent = JSON.parse('{ "hello": "world" }')
 
-    assert.strictEqual(actualContent, expectedContent)
+    assert.deepEqual(jsonContent, expectedContent)
     mock.reset()
     server.close()
   })

--- a/test/fallback.spec.js
+++ b/test/fallback.spec.js
@@ -297,7 +297,7 @@ describe('Client Fallback', () => {
     t.mock.method(mockStorage, 'get')
     t.mock.method(mockStorage, 'set')
 
-    const saturn = new Saturn({ storage: mockStorage, originURL: TEST_CUSTOMER_ORIGIN, ...options })
+    const saturn = new Saturn({ storage: mockStorage, customerFallbackURL: TEST_CUSTOMER_ORIGIN, ...options })
 
     const cid = saturn.fetchContentWithFallback('bafkreifjjcie6lypi6ny7amxnfftagclbuxndqonfipmb64f2km2devei4', { raceNodes: true })
 

--- a/test/fixtures/hello.json
+++ b/test/fixtures/hello.json
@@ -1,0 +1,3 @@
+{
+    "hello": "world"
+}

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -17,23 +17,23 @@ describe('Saturn client', () => {
     it('should work with custom client ID', () => {
       const clientId = randomUUID()
       const saturn = new Saturn({ clientId, clientKey })
-      assert.strictEqual(saturn.opts.clientId, clientId)
+      assert.strictEqual(saturn.config.clientId, clientId)
     })
 
     it('should work with custom CDN URL', () => {
       const cdnURL = 'custom.com'
       const saturn = new Saturn({ cdnURL, clientKey })
-      assert.strictEqual(saturn.opts.cdnURL, cdnURL)
+      assert.strictEqual(saturn.config.cdnURL, cdnURL)
     })
 
     it('should work with custom connect timeout', () => {
       const saturn = new Saturn({ connectTimeout: 1234, clientKey })
-      assert.strictEqual(saturn.opts.connectTimeout, 1234)
+      assert.strictEqual(saturn.config.connectTimeout, 1234)
     })
 
     it('should work with custom download timeout', () => {
       const saturn = new Saturn({ downloadTimeout: 3456, clientKey })
-      assert.strictEqual(saturn.opts.downloadTimeout, 3456)
+      assert.strictEqual(saturn.config.downloadTimeout, 3456)
     })
   })
 

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -46,15 +46,15 @@ export function generateNodes (count, originDomain) {
 /**
  * Generates a mock handler to mimick Saturn's orchestrator /nodes endpoint.
  *
- * @param {string} cdnURL - orchestratorUrl
+ * @param {string} originUrl - originUrl
  * @param {number} delay - request delay in ms
  * @param {boolean} error
  * @returns {RestHandler<any>}
  */
-export function mockSaturnOriginHandler (cdnURL, delay = 0, error = false) {
-  cdnURL = addHttpPrefix(cdnURL)
-  cdnURL = `${cdnURL}/ipfs/:cid`
-  return rest.get(cdnURL, (req, res, ctx) => {
+export function mockOriginHandler (originUrl, delay = 0, error = false) {
+  originUrl = addHttpPrefix(originUrl)
+  originUrl = `${originUrl}/ipfs/:cid`
+  return rest.get(originUrl, (req, res, ctx) => {
     if (error) {
       throw Error('Simulated Error')
     }

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -69,6 +69,31 @@ export function mockOriginHandler (originUrl, delay = 0, error = false) {
 }
 
 /**
+ * Generates a mock handler to mimick an origin that serves flat files.
+ *
+ * @param {string} originUrl - originUrl
+ * @param {number} delay - request delay in ms
+ * @param {boolean} error
+ * @returns {RestHandler<any>}
+ */
+export function mockFlatFileOriginHandler (originUrl, delay = 0, error = false) {
+  originUrl = addHttpPrefix(originUrl)
+  originUrl = `${originUrl}/ipfs/:cid`
+  return rest.get(originUrl, (req, res, ctx) => {
+    if (error) {
+      throw Error('Simulated Error')
+    }
+    const filepath = getFixturePath('hello.json')
+    const fileContents = fs.readFileSync(filepath)
+    return res(
+      ctx.delay(delay),
+      ctx.status(HTTP_STATUS_OK),
+      ctx.body(fileContents)
+    )
+  })
+}
+
+/**
  * Generates a mock handler to mimick Saturn's orchestrator /nodes endpoint.
  *
  * @param {number} count - amount of nodes

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -78,7 +78,6 @@ export function mockOriginHandler (originUrl, delay = 0, error = false) {
  */
 export function mockFlatFileOriginHandler (originUrl, delay = 0, error = false) {
   originUrl = addHttpPrefix(originUrl)
-  originUrl = `${originUrl}`
   return rest.get(originUrl, (req, res, ctx) => {
     if (error) {
       throw Error('Simulated Error')

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -78,7 +78,7 @@ export function mockOriginHandler (originUrl, delay = 0, error = false) {
  */
 export function mockFlatFileOriginHandler (originUrl, delay = 0, error = false) {
   originUrl = addHttpPrefix(originUrl)
-  originUrl = `${originUrl}/ipfs/:cid`
+  originUrl = `${originUrl}`
   return rest.get(originUrl, (req, res, ctx) => {
     if (error) {
       throw Error('Simulated Error')


### PR DESCRIPTION
## Changes:
- Simplified options passing to only use a nodes array instead having (nodes, url, node) as accepted options. 
- Added a fallback to an `originURL` if it exists to fetch data as a final fallback. 