### PR TITLE
Upstream controller don't abort all requests

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -248,9 +248,13 @@ export class Saturn {
    * @param {string} [opts.url]
    * @param {number} [opts.connectTimeout=5000]
    * @param {number} [opts.downloadTimeout=0]
+   * @param {AbortController} [opts.controller]
    * @returns {Promise<AsyncIterable<Uint8Array>>}
    */
   async * fetchContentWithFallback (cidPath, opts = {}) {
+    const upstreamController = opts.controller;
+    delete opts.controller;
+
     let lastError = null
     // we use this to checkpoint at which chunk a request failed.
     // this is temporary until range requests are supported.
@@ -261,6 +265,13 @@ export class Saturn {
     }
 
     const fetchContent = async function * () {
+      const controller = new AbortController();
+      opts.controller = controller;
+      if (upstreamController) {
+        upstreamController.signal.addEventListener('abort', () => {
+          controller.abort();
+        });
+      }
       let byteCount = 0
       const byteChunks = await this.fetchContent(cidPath, opts)
       for await (const chunk of byteChunks) {

--- a/src/client.js
+++ b/src/client.js
@@ -309,7 +309,7 @@ export class Saturn {
     let fallbackCount = 0
     const nodes = this.nodes
     for (let i = 0; i < nodes.length; i++) {
-      if (fallbackCount > this.opts.fallbackLimit) {
+      if (fallbackCount > this.opts.fallbackLimit || upstreamController?.signal.aborted) {
         return
       }
       if (opts.raceNodes) {


### PR DESCRIPTION
When there's an upstream controller passed, don't use it as the one passed to each request, but rather proxy the abort to current one only. Also, if upstream controller was aborted, don't try yielding next fallback