### PR TITLE
feat: enable first hit to origin

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -308,7 +308,13 @@ export class Saturn {
     }
 
     let fallbackCount = 0
-    const nodes = this.nodes
+    let nodes = this.nodes
+    if (opts.firstHitDNS) {
+      nodes = [
+        { url: this.config.cdnURL },
+        ...nodes
+      ]
+    }
     for (let i = 0; i < nodes.length; i++) {
       if (fallbackCount > this.config.fallbackLimit || skipNodes || upstreamController?.signal.aborted) {
         break

--- a/src/types.js
+++ b/src/types.js
@@ -24,7 +24,8 @@
  * @property {string} [jwt] - JWT for L1 request.
  * @property {number} [connectTimeout=5000] - Connection timeout in milliseconds.
  * @property {number} [downloadTimeout=0] - Download timeout in milliseconds.
- * @property {AbortController} [controller]
+ * @property {AbortController} [controller] - Abort controller
+ * @property {boolean} [firstHitDNS] - Is the first request always to DNS
  */
 
 export {}

--- a/src/types.js
+++ b/src/types.js
@@ -25,7 +25,7 @@
  * @property {number} [connectTimeout=5000] - Connection timeout in milliseconds.
  * @property {number} [downloadTimeout=0] - Download timeout in milliseconds.
  * @property {AbortController} [controller] - Abort controller
- * @property {boolean} [firstHitDNS] - Is the first request always to DNS
+ * @property {boolean} [firstHitDNS] - First request hit is always to CDN origin.
  */
 
 export {}


### PR DESCRIPTION
## Changes

This addresses the current drop in the smart client perf due to the geolocation inaccuracy. It allows the cdn origin to be hit first on every request based on a boolean option. 

