### PR TITLE
Support range requests

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -392,7 +392,7 @@ export class Saturn {
       if (!opts.format) {
         yield * itr
       } else {
-        yield * extractVerifiedContent(cidPath, itr)
+        yield * extractVerifiedContent(cidPath, itr, opts.range || {})
       }
     } catch (err) {
       log.error = err.message
@@ -422,6 +422,7 @@ export class Saturn {
    * @param {string} [opts.format]
    * @param {string} [opts.originFallback]
    * @param {object} [opts.jwt]
+   * @param {import('./types.js').ContentRange} [opts.range]
    * @returns {URL}
    */
   createRequestURL (cidPath, opts = {}) {
@@ -442,6 +443,11 @@ export class Saturn {
       url.searchParams.set('jwt', opts.jwt)
     }
 
+    if (typeof opts.range === 'object' && (opts.range.rangeStart || opts.range.rangeEnd)) {
+      const rangeStart = opts.range.rangeStart?.toString() || '0'
+      const rangeEnd = opts.range.rangeEnd?.toString() || '*'
+      url.searchParams.set('entity-bytes', rangeStart + ':' + rangeEnd)
+    }
     return url
   }
 

--- a/src/types.js
+++ b/src/types.js
@@ -18,6 +18,7 @@
  * @typedef {object} FetchOptions
  * @property {Node[]} [nodes] - An array of nodes.
  * @property {('car'|'raw')} [format] - The format of the fetched content.
+ * 
  * @property {boolean} [originFallback] - Is this a fallback to the customer origin
  * @property {boolean} [raceNodes] - Does the fetch race multiple nodes on requests.
  * @property {string} [customerFallbackURL] - Customer Origin that is a fallback.
@@ -26,6 +27,15 @@
  * @property {number} [downloadTimeout=0] - Download timeout in milliseconds.
  * @property {AbortController} [controller] - Abort controller
  * @property {boolean} [firstHitDNS] - First request hit is always to CDN origin.
+ * @property {ContentRange} [range] - range to fetch, compatible with entity bytes parameter
+ */
+
+/**
+ * Options for a range request
+ *
+ * @typedef {object} ContentRange
+ * @property {number} [rangeStart]
+ * @property {number} [rangeEnd]
  */
 
 export {}

--- a/test/car.spec.js
+++ b/test/car.spec.js
@@ -23,6 +23,62 @@ describe('CAR Verification', () => {
     assert.strictEqual(actualContent, expectedContent)
   })
 
+  it('should extract content from a valid CAR with a range', async () => {
+    const cidPath =
+      'bafkreifjjcie6lypi6ny7amxnfftagclbuxndqonfipmb64f2km2devei4'
+    const filepath = getFixturePath('hello.car')
+    const carStream = fs.createReadStream(filepath)
+
+    const contentItr = await extractVerifiedContent(cidPath, carStream, {rangeStart: 1, rangeEnd: 3})
+    const buffer = await concatChunks(contentItr)
+    const actualContent = String.fromCharCode(...buffer)
+    const expectedContent = 'ell'
+
+    assert.strictEqual(actualContent, expectedContent)
+  })
+
+  it('should extract content from a valid CAR with a range with only a start', async () => {
+    const cidPath =
+      'bafkreifjjcie6lypi6ny7amxnfftagclbuxndqonfipmb64f2km2devei4'
+    const filepath = getFixturePath('hello.car')
+    const carStream = fs.createReadStream(filepath)
+
+    const contentItr = await extractVerifiedContent(cidPath, carStream, {rangeStart: 1})
+    const buffer = await concatChunks(contentItr)
+    const actualContent = String.fromCharCode(...buffer)
+    const expectedContent = 'ello world\n'
+
+    assert.strictEqual(actualContent, expectedContent)
+  })
+
+  it('should extract content from a valid CAR with a range with a negative end', async () => {
+    const cidPath =
+      'bafkreifjjcie6lypi6ny7amxnfftagclbuxndqonfipmb64f2km2devei4'
+    const filepath = getFixturePath('hello.car')
+    const carStream = fs.createReadStream(filepath)
+
+    const contentItr = await extractVerifiedContent(cidPath, carStream, {rangeStart: 1, rangeEnd: -1})
+    const buffer = await concatChunks(contentItr)
+    const actualContent = String.fromCharCode(...buffer)
+    const expectedContent = 'ello world'
+
+    assert.strictEqual(actualContent, expectedContent)
+  })
+
+  it('should extract content from a valid CAR with a range with a negative start and end', async () => {
+    const cidPath =
+      'bafkreifjjcie6lypi6ny7amxnfftagclbuxndqonfipmb64f2km2devei4'
+    const filepath = getFixturePath('hello.car')
+    const carStream = fs.createReadStream(filepath)
+
+    const contentItr = await extractVerifiedContent(cidPath, carStream, {rangeStart: -5, rangeEnd: -1})
+    const buffer = await concatChunks(contentItr)
+    const actualContent = String.fromCharCode(...buffer)
+    const expectedContent = 'orld'
+
+    assert.strictEqual(actualContent, expectedContent)
+  })
+
   it('should verify intermediate path segments', async () => {
     const cidPath =
       'bafybeigeqgfwhivuuxgmuvcrrwvs4j3yfzgljssvnuqzokm6uby4fpmwsa/subdir/hello.txt'

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -81,6 +81,18 @@ describe('Saturn client', () => {
     })
   })
 
+  describe('Create a request URL', () => {
+    const client = new Saturn({ clientKey })
+    it('should translate entity bytes params', () => {
+      assert.strictEqual(client.createRequestURL('bafy...').searchParams.get('entity-bytes'), null)
+      assert.strictEqual(client.createRequestURL('bafy...', { range: {} }).searchParams.get('entity-bytes'), null)
+      assert.strictEqual(client.createRequestURL('bafy...', { range: { rangeStart: 0 } }).searchParams.get('entity-bytes'), null)
+      assert.strictEqual(client.createRequestURL('bafy...', { range: { rangeStart: 10 } }).searchParams.get('entity-bytes'), '10:*')
+      assert.strictEqual(client.createRequestURL('bafy...', { range: { rangeStart: 10, rangeEnd: 20 } }).searchParams.get('entity-bytes'), '10:20')
+      assert.strictEqual(client.createRequestURL('bafy...', { range: { rangeEnd: 20 } }).searchParams.get('entity-bytes'), '0:20')
+    })
+  })
+
   describe('Logging', () => {
     const handlers = [
       mockJWT(TEST_AUTH)


### PR DESCRIPTION
# Goals

Support range requests in the client. For now, only supports one HTTP range (FWIW, the HTTP range spec allows multiple ranges to be specified -- I don't think that gets used for video and audio)

# Implementation

So it turns out ipfs-unixfs-exporter already has range support of a kind -- when you call node.content() you can pass ExporterOptions object with and offset and length, and it will properly return the right data, loading the correct blocks. (I think)

What is needed then is just to do the right parsing -- http ranges are pretty weird -- they support negatives and also missing end values.

This adds a range property to the FetchOptions that has a rangeStart and rangeEnd parameter, which should correspond to the integer values in the range parameter (i.e. 'bytes=0-1000' becomes `{rangeStart:0, rangeEnd: 1000}`)

There are two things to do with this parameter

1. pass it to the L1's as entity bytes -- so you get the right blocks in the response.
2. Convert to offset/length params on unixfs-exporter to do ranged verification

# Next steps

I've made a similar change to actually read the range header in the service worker (PR incoming).

This should be a complete solution from a raw implementation standpoint, but it needs further testing. There are unit tests of the changes, but little integration testing.

In particular, the UnixFS exporter range requests are tested against a single block file. We need to make a test that verifies it works with a multi-block file.

We also probably need a round trip integration test that verifies we can make a request (fetchContent or fetchContentWithFallback) with the range option set, and the expected URL will go to the backend, and given the proper car response, it verifies.

The good news is I believe, at least tentatively, that we can make this all work without getting into unixfs-exporter code.