### PR TITLE
feat: update storage initiation

### DIFF
--- a/src/storage/indexed-db-storage.js
+++ b/src/storage/indexed-db-storage.js
@@ -8,22 +8,39 @@ const DEFAULT_SATURN_STORAGE_NAME = 'saturn-client'
 
 /**
  * @function indexedDbStorage
- * @returns {import('./index.js').Storage}
+ * @returns {function():Promise<import('./index.js').Storage>}
  */
 export function indexedDbStorage () {
-  const indexedDbExists = (typeof self !== 'undefined') && self?.indexedDB
+  const indexedDbExists = typeof self !== 'undefined' && self?.indexedDB
   let dbPromise
-  if (indexedDbExists) {
-    dbPromise = openDB(DEFAULT_IDB_STORAGE_NAME, DEFAULT_IDB_VERSION, {
-      upgrade (db) {
-        db.createObjectStore(DEFAULT_SATURN_STORAGE_NAME)
-      }
-    })
-  }
 
-  return {
-    get: async (key) => indexedDbExists && (await dbPromise).get(DEFAULT_SATURN_STORAGE_NAME, key),
-    set: async (key, value) => indexedDbExists && (await dbPromise).put(DEFAULT_SATURN_STORAGE_NAME, value, key),
-    delete: async (key) => indexedDbExists && (await dbPromise).delete(DEFAULT_SATURN_STORAGE_NAME, key)
+  return async () => {
+    if (!indexedDbExists) {
+      throw Error('Indexed DB is not supported in this environment')
+    }
+
+    if (indexedDbExists) {
+      dbPromise = await openDB(DEFAULT_IDB_STORAGE_NAME, DEFAULT_IDB_VERSION, {
+        upgrade (db) {
+          try {
+            db.createObjectStore(DEFAULT_SATURN_STORAGE_NAME)
+          } catch (error) {
+            throw Error(`Cannot initialize indexed DB Object store, error: ${error}`)
+          }
+        }
+      })
+    }
+
+    return {
+      get: async (key) =>
+        indexedDbExists &&
+        (await dbPromise).get(DEFAULT_SATURN_STORAGE_NAME, key),
+      set: async (key, value) =>
+        indexedDbExists &&
+        (await dbPromise).put(DEFAULT_SATURN_STORAGE_NAME, value, key),
+      delete: async (key) =>
+        indexedDbExists &&
+        (await dbPromise).delete(DEFAULT_SATURN_STORAGE_NAME, key)
+    }
   }
 }

--- a/src/storage/memory-storage.js
+++ b/src/storage/memory-storage.js
@@ -2,14 +2,15 @@
 
 /**
  * @function memoryStorage
- * @returns {import('./index.js').Storage}
+ * @returns {function():Promise<import('./index.js').Storage>}
  */
 export function memoryStorage () {
   const storageObject = {}
 
-  return {
+  const storage = {
     get: async (key) => storageObject[key],
     set: async (key, value) => { storageObject[key] = value },
     delete: async (key) => { delete storageObject[key] }
   }
+  return async () => storage
 }

--- a/test/fallback.spec.js
+++ b/test/fallback.spec.js
@@ -52,20 +52,19 @@ describe('Client Fallback', () => {
 
     const expectedNodes = generateNodes(2, TEST_ORIGIN_DOMAIN)
 
-    // Mocking storage object
     const mockStorage = {
-      get: async (key) => null,
-      set: async (key, value) => null,
-      delete: async (key) => null
+      get: async (key) => expectedNodes,
+      set: async (key, value) => { return null }
     }
+    // Mocking storage object
+    const storage = async () => mockStorage
     t.mock.method(mockStorage, 'get')
     t.mock.method(mockStorage, 'set')
 
-    const saturn = new Saturn({ storage: mockStorage, ...options })
+    const saturn = new Saturn({ storage, ...options })
 
     // Mocking options
     const mockOpts = { orchURL: TEST_DEFAULT_ORCH }
-
     await saturn._loadNodes(mockOpts)
 
     // Assert that all the storage methods were called twice.
@@ -98,7 +97,8 @@ describe('Client Fallback', () => {
     t.mock.method(mockStorage, 'get')
     t.mock.method(mockStorage, 'set')
 
-    const saturn = new Saturn({ storage: mockStorage, ...options })
+    const storage = async () => mockStorage
+    const saturn = new Saturn({ storage, ...options })
 
     // Mocking options
     const mockOpts = { orchURL: TEST_DEFAULT_ORCH }
@@ -137,7 +137,8 @@ describe('Client Fallback', () => {
     t.mock.method(mockStorage, 'get')
     t.mock.method(mockStorage, 'set')
 
-    const saturn = new Saturn({ storage: mockStorage, ...options })
+    const storage = async () => mockStorage
+    const saturn = new Saturn({ storage, ...options })
 
     const cid = saturn.fetchContentWithFallback('bafkreifjjcie6lypi6ny7amxnfftagclbuxndqonfipmb64f2km2devei4')
 
@@ -167,10 +168,13 @@ describe('Client Fallback', () => {
       get: async (key) => expectedNodes,
       set: async (key, value) => { return null }
     }
+
     t.mock.method(mockStorage, 'get')
     t.mock.method(mockStorage, 'set')
 
-    const saturn = new Saturn({ ...options })
+    const storage = async () => mockStorage
+
+    const saturn = new Saturn({ storage, ...options })
 
     const cid = saturn.fetchContentWithFallback('bafkreifjjcie6lypi6ny7amxnfftagclbuxndqonfipmb64f2km2devei4', { raceNodes: true })
 
@@ -203,7 +207,9 @@ describe('Client Fallback', () => {
     t.mock.method(mockStorage, 'get')
     t.mock.method(mockStorage, 'set')
 
-    const saturn = new Saturn({ ...options })
+    const storage = async () => mockStorage
+
+    const saturn = new Saturn({ storage, ...options })
 
     await saturn.loadNodesPromise
 
@@ -242,7 +248,8 @@ describe('Client Fallback', () => {
     t.mock.method(mockStorage, 'get')
     t.mock.method(mockStorage, 'set')
 
-    const saturn = new Saturn({ storage: mockStorage, ...options })
+    const storage = async () => mockStorage
+    const saturn = new Saturn({ storage, ...options })
 
     const cid = saturn.fetchContentWithFallback('bafkreifjjcie6lypi6ny7amxnfftagclbuxndqonfipmb64f2km2devei4', { raceNodes: true })
 
@@ -336,7 +343,9 @@ describe('Client Fallback', () => {
     t.mock.method(mockStorage, 'get')
     t.mock.method(mockStorage, 'set')
 
-    const saturn = new Saturn({ storage: mockStorage, customerFallbackURL: TEST_CUSTOMER_ORIGIN, ...options })
+    const storage = async () => mockStorage
+
+    const saturn = new Saturn({ storage, customerFallbackURL: TEST_CUSTOMER_ORIGIN, ...options })
 
     const cid = saturn.fetchContentWithFallback(TEST_CUSTOMER_ORIGIN, { raceNodes: true })
 


### PR DESCRIPTION
## Description

This PR addresses: https://github.com/filecoin-saturn/project-tracking/issues/161

The PR changes the storage interface to act as a factory function for storage. This means when we inject storage as a dependency, it returns a function which initiates the storage vs returning the storage getters, setters, etc. right away. 

What this improves:
- Any smart client functionality relies on some form of storage dependency to work. If we inject a storage dependency that is faulty, we must detect that as early as possible and replace it with a memory storage instance.
- This allows us to catch issues with storage loading before attempting to utilize any storage functionality.
