### PR TITLE
WIP: Return content range data immediately

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@ipld/dag-pb": "^2.1.18",
         "@multiformats/blake2": "^1.0.11",
         "browser-readablestream-to-it": "^2.0.4",
+        "content-range": "^2.0.2",
         "hashring": "^3.2.0",
         "idb": "^7.1.1",
         "ipfs-unixfs-exporter": "https://gitpkg.now.sh/filecoin-saturn/js-ipfs-unixfs/packages/ipfs-unixfs-exporter?build",
@@ -1573,6 +1574,15 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz",
       "integrity": "sha512-bTTG28diWg7R7/+qE5NZumwPbCiJOT8uPdZYu674brDjBWQctbaQbYlDKhalS+4i5HxIx+G8dZsnBHKzWpp01A=="
+    },
+    "node_modules/content-range": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/content-range/-/content-range-2.0.2.tgz",
+      "integrity": "sha512-ayHd/VQMRfWFBLVXyYvNhbbR+vq5OgLJnViGV4arzQiX9odRhf1spmXF7pFEHiR8htli29Hbii0URCNfUTN4vQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      }
     },
     "node_modules/cookie": {
       "version": "0.4.2",
@@ -6928,6 +6938,11 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz",
       "integrity": "sha512-bTTG28diWg7R7/+qE5NZumwPbCiJOT8uPdZYu674brDjBWQctbaQbYlDKhalS+4i5HxIx+G8dZsnBHKzWpp01A=="
+    },
+    "content-range": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/content-range/-/content-range-2.0.2.tgz",
+      "integrity": "sha512-ayHd/VQMRfWFBLVXyYvNhbbR+vq5OgLJnViGV4arzQiX9odRhf1spmXF7pFEHiR8htli29Hbii0URCNfUTN4vQ=="
     },
     "cookie": {
       "version": "0.4.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@ipld/dag-pb": "^2.1.18",
     "@multiformats/blake2": "^1.0.11",
     "browser-readablestream-to-it": "^2.0.4",
+    "content-range": "^2.0.2",
     "hashring": "^3.2.0",
     "idb": "^7.1.1",
     "ipfs-unixfs-exporter": "https://gitpkg.now.sh/filecoin-saturn/js-ipfs-unixfs/packages/ipfs-unixfs-exporter?build",

--- a/src/types.js
+++ b/src/types.js
@@ -34,8 +34,16 @@
  * Options for a range request
  *
  * @typedef {object} ContentRange
- * @property {number} [rangeStart]
- * @property {number} [rangeEnd]
+ * @property {number | null } [rangeStart]
+ * @property {number | null } [rangeEnd]
+ */
+
+/**
+ * Response to fetchContent
+ * @typedef {object} Response
+ * @property {number} totalSize
+ * @property {ContentRange | undefined} range
+ * @property {AsyncIterable<Uint8Array>} body
  */
 
 export {}

--- a/test/car.spec.js
+++ b/test/car.spec.js
@@ -6,7 +6,7 @@ import { getFixturePath, concatChunks } from './test-utils.js'
 import { CarReader, CarWriter } from '@ipld/car'
 import { CID } from 'multiformats/cid'
 
-import { extractVerifiedContent } from '#src/utils/car.js'
+import { extractVerifiedContent, extractVerifiedEntity } from '../src/index.js'
 
 describe('CAR Verification', () => {
   it('should extract content from a valid CAR', async () => {
@@ -15,7 +15,8 @@ describe('CAR Verification', () => {
     const filepath = getFixturePath('hello.car')
     const carStream = fs.createReadStream(filepath)
 
-    const contentItr = await extractVerifiedContent(cidPath, carStream)
+    const node = await extractVerifiedEntity(cidPath, carStream)
+    const contentItr = extractVerifiedContent(node)
     const buffer = await concatChunks(contentItr)
     const actualContent = String.fromCharCode(...buffer)
     const expectedContent = 'hello world\n'
@@ -29,7 +30,8 @@ describe('CAR Verification', () => {
     const filepath = getFixturePath('hello.car')
     const carStream = fs.createReadStream(filepath)
 
-    const contentItr = await extractVerifiedContent(cidPath, carStream, {rangeStart: 1, rangeEnd: 3})
+    const node = await extractVerifiedEntity(cidPath, carStream)
+    const contentItr = extractVerifiedContent(node, { rangeStart: 1, rangeEnd: 3 })
     const buffer = await concatChunks(contentItr)
     const actualContent = String.fromCharCode(...buffer)
     const expectedContent = 'ell'
@@ -43,7 +45,8 @@ describe('CAR Verification', () => {
     const filepath = getFixturePath('hello.car')
     const carStream = fs.createReadStream(filepath)
 
-    const contentItr = await extractVerifiedContent(cidPath, carStream, {rangeStart: 1})
+    const node = await extractVerifiedEntity(cidPath, carStream)
+    const contentItr = extractVerifiedContent(node, { rangeStart: 1 })
     const buffer = await concatChunks(contentItr)
     const actualContent = String.fromCharCode(...buffer)
     const expectedContent = 'ello world\n'
@@ -57,7 +60,8 @@ describe('CAR Verification', () => {
     const filepath = getFixturePath('hello.car')
     const carStream = fs.createReadStream(filepath)
 
-    const contentItr = await extractVerifiedContent(cidPath, carStream, {rangeStart: 1, rangeEnd: -1})
+    const node = await extractVerifiedEntity(cidPath, carStream)
+    const contentItr = extractVerifiedContent(node, { rangeStart: 1, rangeEnd: -1 })
     const buffer = await concatChunks(contentItr)
     const actualContent = String.fromCharCode(...buffer)
     const expectedContent = 'ello world'
@@ -71,7 +75,8 @@ describe('CAR Verification', () => {
     const filepath = getFixturePath('hello.car')
     const carStream = fs.createReadStream(filepath)
 
-    const contentItr = await extractVerifiedContent(cidPath, carStream, {rangeStart: -5, rangeEnd: -1})
+    const node = await extractVerifiedEntity(cidPath, carStream)
+    const contentItr = extractVerifiedContent(node, {rangeStart: -5, rangeEnd: -1})
     const buffer = await concatChunks(contentItr)
     const actualContent = String.fromCharCode(...buffer)
     const expectedContent = 'orld'
@@ -83,8 +88,8 @@ describe('CAR Verification', () => {
     const cidPath = 'QmStvUMCtXxEb8wRjNSUqWwqHBEDhmnEd5nHp5siV7bm1Z'
     const filepath = getFixturePath('multi_block_filtered.car')
     const carStream = fs.createReadStream(filepath)
-
-    const contentItr = await extractVerifiedContent(cidPath, carStream, { rangeStart: 300, rangeEnd: 349 })
+    const node = await extractVerifiedEntity(cidPath, carStream)
+    const contentItr = extractVerifiedContent(node, { rangeStart: 300, rangeEnd: 349 })
     const buffer = await concatChunks(contentItr)
     const actualContent = Buffer.from(buffer).toString('base64')
 
@@ -102,7 +107,8 @@ describe('CAR Verification', () => {
     const filepath = getFixturePath('subdir.car')
     const carStream = fs.createReadStream(filepath)
 
-    const contentItr = await extractVerifiedContent(cidPath, carStream)
+    const node = await extractVerifiedEntity(cidPath, carStream)
+    const contentItr = extractVerifiedContent(node)
     const buffer = await concatChunks(contentItr)
     const actualContent = String.fromCharCode(...buffer)
     const expectedContent = 'hello world\n'
@@ -116,7 +122,8 @@ describe('CAR Verification', () => {
     const filepath = getFixturePath('dag-cbor-with-identity.car')
     const carStream = fs.createReadStream(filepath)
 
-    const contentItr = await extractVerifiedContent(cidPath, carStream)
+    const node = await extractVerifiedEntity(cidPath, carStream)
+    const contentItr = extractVerifiedContent(node)
     const itr = contentItr[Symbol.asyncIterator]()
     const actualContent = (await itr.next()).value
     const expectedContent = { asdf: 324 }
@@ -130,7 +137,8 @@ describe('CAR Verification', () => {
     const filepath = getFixturePath('dag-cbor-traversal.car')
     const carStream = fs.createReadStream(filepath)
 
-    const contentItr = await extractVerifiedContent(cidPath, carStream)
+    const node = await extractVerifiedEntity(cidPath, carStream)
+    const contentItr = extractVerifiedContent(node)
     const itr = contentItr[Symbol.asyncIterator]()
     const actualContent = (await itr.next()).value
     const expectedContent = { hello: 'this is not a link' }
@@ -144,7 +152,8 @@ describe('CAR Verification', () => {
     const filepath = './fixtures/dag-json-traversal.car'
     const carStream = fs.createReadStream(filepath)
 
-    const contentItr = await extractVerifiedContent(cidPath, carStream)
+    const node = await extractVerifiedEntity(cidPath, carStream)
+    const contentItr = extractVerifiedContent(node)
     const itr = contentItr[Symbol.asyncIterator]()
     const actualContent = (await itr.next()).value
     const expectedContent = { hello: 'this is not a link' }
@@ -169,7 +178,8 @@ describe('CAR Verification', () => {
 
     await assert.rejects(
       async () => {
-        for await (const _ of extractVerifiedContent(cidPath, out)) {}
+        const node = await extractVerifiedEntity(cidPath, out)
+        for await (const _ of extractVerifiedContent(node)) {}
       },
       {
         name: 'VerificationError',
@@ -207,7 +217,8 @@ describe('CAR Verification', () => {
 
     await assert.rejects(
       async () => {
-        for await (const _ of extractVerifiedContent(cidPath, out)) {}
+        const node = await extractVerifiedEntity(cidPath, out)
+        for await (const _ of extractVerifiedContent(node)) {}
       },
       {
         name: 'VerificationError',

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -91,7 +91,8 @@ describe('Saturn client', () => {
 
     it('should create a log on fetch success', async () => {
       client.reportingLogs = true
-      for await (const _ of client.fetchContent(HELLO_CID)) {} // eslint-disable-line
+      const response = await client.fetchContent(HELLO_CID)
+      for await (const _ of response.body) {} // eslint-disable-line
 
       const log = client.logs.pop()
 


### PR DESCRIPTION
# Goals

Still working on this but this would return the data needed to set a content-range header in the service worker needed for video. The only problem: big signature change to fetchContent. It now returns a promise which contains the information needed for content length AND the async iterable.

# Done

- car functions changes (still messing around with these)
- Saturn.fetchContent

# TO DO

- Implement fetchContentWithFallback so that it ALSO returns the same signature (not easy - for now I've just compressed the call to fetchContent)
- Implement fetchContentBuffer so that it returns a comparable signature
- Get tests passing

# For discussion

The complexity add to do this is non-trivial (especially with fetchContentWithFallback). Maybe there's a better solution? I'm not sure there is though.

