### PR TITLE
Add null check

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -518,7 +518,7 @@ export class Saturn {
     // It's a good enough heuristic.
     const entry = performance
       .getEntriesByType('resource')
-      .find((r) => r.name === log.url.href)
+      .find((r) => r.name === log.url?.href)
 
     if (entry) {
       const dnsStart = entry.domainLookupStart


### PR DESCRIPTION
# Goals

Fix this error from sentry, as a fail against all attempts with `fetchCIDwithRace` can produce a log without a URL https://filecoin-saturn.sentry.io/issues/4875898271/?project=4505902296858624&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0

# Implementation

Add  null check