### PR TITLE
Fix changing gitpkg sha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3279,7 +3279,7 @@
     "node_modules/ipfs-unixfs-exporter": {
       "version": "13.2.1",
       "resolved": "https://gitpkg.now.sh/filecoin-saturn/js-ipfs-unixfs/packages/ipfs-unixfs-exporter?build",
-      "integrity": "sha512-ny6QvsNAet0oJKWAU6+0ctL7bKzO4rZ/7Jix+zG3rZ9SFmBP7v/8EFUrNhP6I2hXukiiGxUwdkxH35q0aC2VLg==",
+      "integrity": "sha512-jZFDVb4GAOay+Rs99ktfHq9jYxIDdl3HGIDVMUjgUDn44pdV8kEA/4bFbmx/7Xe7qAvn8mIs90i8yDFQ27rRSA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.0",
@@ -8210,7 +8210,7 @@
     },
     "ipfs-unixfs-exporter": {
       "version": "https://gitpkg.now.sh/filecoin-saturn/js-ipfs-unixfs/packages/ipfs-unixfs-exporter?build",
-      "integrity": "sha512-ny6QvsNAet0oJKWAU6+0ctL7bKzO4rZ/7Jix+zG3rZ9SFmBP7v/8EFUrNhP6I2hXukiiGxUwdkxH35q0aC2VLg==",
+      "integrity": "sha512-jZFDVb4GAOay+Rs99ktfHq9jYxIDdl3HGIDVMUjgUDn44pdV8kEA/4bFbmx/7Xe7qAvn8mIs90i8yDFQ27rRSA==",
       "requires": {
         "@ipld/dag-cbor": "^9.0.0",
         "@ipld/dag-pb": "^4.0.0",


### PR DESCRIPTION
# Goals

Fix CI

# Implementation

I'm chalking this up to https://github.com/EqualMa/gitpkg/issues/39 - gitpkg apparently just randomly breaks shas sometimes. The fact that someone in the comments had the same issue in approximately the timeframe it appeared for us, plus this commit: https://github.com/EqualMa/gitpkg/commit/bd5f1dd830e6f0ad1ab95a27c8119b1ea5558798 matching the timeline gives me high enough confidence this isn't an us problem.

So I just updated package-lock.json with the new SHA